### PR TITLE
ag7240: properly validate mac addresses

### DIFF
--- a/u-boot/cpu/mips/ar7240/ag7240.c
+++ b/u-boot/cpu/mips/ar7240/ag7240.c
@@ -482,10 +482,9 @@ static void ag7240_get_ethaddr(struct eth_device *dev)
         printf("%s: unknown ethernet device %s\n", __func__, dev->name);
         return;
     }
-    /* Use fixed address if the above address is invalid */
-    if (mac[0] != 0x00 || (mac[0] == 0xff && mac[5] == 0xff) ||
-	(mac[1] == 0x00 && mac[2] == 0x00 &&
-	mac[3] == 0x00 && mac[4] == 0x00)) {
+    /* Only allow globally unique, unicast addresses */
+    if (CHECK_BIT((mac[0] & 0xFF), 0) != 0 ||
+            CHECK_BIT((mac[0] & 0xFF), 1) != 0) {
 #else
     if (1) {
 #endif 
@@ -497,7 +496,7 @@ static void ag7240_get_ethaddr(struct eth_device *dev)
         mac[5] = 0xad;
         debug("No valid address in Flash. Using fixed address\n");
     } else {
-        debug("Fetching MAC Address from 0x%p\n", __func__, eeprom);
+        debug("Fetching MAC Address from 0x%p\n", eeprom);
     }
 }
 


### PR DESCRIPTION
Check for valid was... odd.  Should accept any mac address that is
unicast and not locally adminstered.

Fix the print of the mac src address uncovered by finally actually
_using_ the mac addresses from BOARDCAL.

Signed-off-by: Karl Palsson <karlp@etactica.com>

(Note, doesn't help my windows dhcp problems, but hey, still an improvement :)